### PR TITLE
shorten method name

### DIFF
--- a/tang-commons/src/main/java/com/tang/commons/utils/SpringUtils.java
+++ b/tang-commons/src/main/java/com/tang/commons/utils/SpringUtils.java
@@ -24,7 +24,7 @@ public final class SpringUtils implements BeanFactoryPostProcessor, ApplicationC
         SpringUtils.beanFactory = beanFactory;
     }
 
-    private static void setStaticApplicationContext(ApplicationContext applicationContext) {
+    private static void setStaticAppCtx(ApplicationContext applicationContext) {
         SpringUtils.applicationContext = applicationContext;
     }
 
@@ -35,7 +35,7 @@ public final class SpringUtils implements BeanFactoryPostProcessor, ApplicationC
 
     @Override
     public void setApplicationContext(@NonNull ApplicationContext applicationContext) throws BeansException {
-        SpringUtils.setStaticApplicationContext(applicationContext);
+        SpringUtils.setStaticAppCtx(applicationContext);
     }
 
     public static ConfigurableListableBeanFactory getBeanFactory() {


### PR DESCRIPTION
Shorten method name "setStaticApplicationContext" to "setStaticAppCtx", and "App" and "Ctx" are common abbreviations. The short method name still follows a standard naming convention and accurately describes the purpose of the method in a more concise way. The short name is easier to read and type.